### PR TITLE
Fix bracketed paste preventing message submission in Claude Code

### DIFF
--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -2390,9 +2390,11 @@ export async function runRun(): Promise<void> {
                 if (typingTarget) channel.setTyping(typingTarget, true);
                 for (const gid of subscribedGroups) channel.setTyping(gid, true);
               }
-              // Send remote text as bracketed paste so special chars (like '@')
-              // stay literal and don't trigger interactive pickers/autocomplete.
-              terminal.write(encodeBracketedPaste(line));
+              // Write text directly to PTY (avoid bracketed paste — recent Claude Code
+              // versions treat Enter as newline-in-input after a paste instead of submit).
+              // Writing the full text in one call delivers it as a single chunk, so
+              // trigger chars like '@' don't activate pickers mid-stream.
+              terminal.write(line);
               // File paths need extra time for the tool to load/process the attachment
               const hasFilePath = line.includes("/.touchgrass/uploads/");
               await delay(hasFilePath ? 1500 : 100);


### PR DESCRIPTION
## Summary
- Stop wrapping remote Telegram input in bracketed paste (`\x1b[200~...\x1b[201~`) before writing to the PTY
- Recent Claude Code versions enter a multi-line editing state after a bracketed paste, causing `\r` (Enter) to add a newline instead of submitting
- Write text directly via `terminal.write(line)` — the full string arrives as a single chunk, so trigger chars like `@` don't activate pickers mid-stream

Closes #1

## Test plan
- Run `tg claude` and send a message from Telegram DM
- Verify the message appears in Claude Code and is submitted (not stuck with a trailing newline)
- Test with messages containing `@` to confirm no picker is triggered