### PR TITLE
feat: enhance terminal bridge and session controls

### DIFF
--- a/packages/cli/src/__tests__/bridge-prompt.test.ts
+++ b/packages/cli/src/__tests__/bridge-prompt.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { __cliRunTestUtils } from "../cli/run";
+
+describe("bridge prompt injection", () => {
+  it("detects gemini initial prompt", () => {
+    const shouldInject = __cliRunTestUtils.shouldInjectBridgePrompt("gemini", "> ", "some previous output > ");
+    expect(shouldInject).toBe(true);
+  });
+
+  it("detects pi initial prompt", () => {
+    const shouldInject = __cliRunTestUtils.shouldInjectBridgePrompt("pi", "? ", "What is the plan? ");
+    expect(shouldInject).toBe(true);
+  });
+
+  it("detects fallback prompt (e.g. for unknown tools)", () => {
+    // Falls back to ["> ", "? "]
+    const shouldInject = __cliRunTestUtils.shouldInjectBridgePrompt("unknown", "> ", "> ");
+    expect(shouldInject).toBe(true);
+  });
+
+  it("does not detect prompt when it's not present", () => {
+    const shouldInject = __cliRunTestUtils.shouldInjectBridgePrompt("gemini", "Calculating...", "Calculating...");
+    expect(shouldInject).toBe(false);
+  });
+
+  it("detects prompt when it's part of a larger buffer", () => {
+    const shouldInject = __cliRunTestUtils.shouldInjectBridgePrompt("kimi", "Done! ? ", "previous output. Done! ? ");
+    expect(shouldInject).toBe(true);
+  });
+
+  it("returns the correct bridge prompt text", () => {
+    const text = __cliRunTestUtils.getBridgePromptText();
+    expect(text).toContain("terminal bridge");
+    expect(text).toContain("proxied from a chat interface");
+    expect(text).toContain("touchgrass");
+  });
+});

--- a/packages/cli/src/__tests__/codex-args.test.ts
+++ b/packages/cli/src/__tests__/codex-args.test.ts
@@ -92,11 +92,13 @@ describe("resume restart arg building", () => {
   it("preserves codex dangerous flags while swapping resume target", () => {
     const args = __cliRunTestUtils.buildResumeCommandArgs(
       "codex",
-      ["--dangerously-bypass-approvals-and-sandbox", "resume", "019c-old"],
+      ["--dangerously-bypass-approvals-and-sandbox", "--append-system-prompt", "AGENTS.md", "resume", "019c-old"],
       "019c-new"
     );
 
     expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain("AGENTS.md");
     expect(args.slice(-2)).toEqual(["resume", "019c-new"]);
     expect(args).not.toContain("019c-old");
   });

--- a/packages/cli/src/__tests__/stdin-input.test.ts
+++ b/packages/cli/src/__tests__/stdin-input.test.ts
@@ -101,3 +101,62 @@ describe("stdin input pending file mentions", () => {
     );
   });
 });
+
+describe("kill switch", () => {
+  it("sends interrupt for /q or 'stop' and does not push to input queue", async () => {
+    const config = createDefaultConfig();
+    const sessionManager = new SessionManager(defaultSettings);
+    const remote = sessionManager.registerRemote(
+      "codex",
+      "telegram:-100:4",
+      "telegram:1",
+      "/tmp/repo",
+      "r-test03"
+    );
+    sessionManager.attach("telegram:-100:4", remote.id);
+
+    const sent: string[] = [];
+    const ctx = {
+      config,
+      sessionManager,
+      channel: {
+        fmt: {
+          code: (v: string) => v,
+          escape: (v: string) => v,
+        },
+        send: async (_chatId: string, text: string) => {
+          sent.push(text);
+        },
+      },
+    } as any;
+
+    // Test /q
+    await handleStdinInput(
+      {
+        userId: "telegram:1",
+        chatId: "telegram:-100:4",
+        text: "/q",
+      },
+      ctx
+    );
+
+    expect(remote.controlAction).toBe("stop");
+    expect(remote.inputQueue.length).toBe(0);
+    expect(sent[0]).toContain("Interruption sent");
+
+    // Test stop
+    remote.controlAction = null;
+    await handleStdinInput(
+      {
+        userId: "telegram:1",
+        chatId: "telegram:-100:4",
+        text: "STOP",
+      },
+      ctx
+    );
+
+    expect(remote.controlAction).toBe("stop");
+    expect(remote.inputQueue.length).toBe(0);
+    expect(sent[1]).toContain("Interruption sent");
+  });
+});

--- a/packages/cli/src/bot/handlers/stdin-input.ts
+++ b/packages/cli/src/bot/handlers/stdin-input.ts
@@ -31,6 +31,19 @@ export async function handleStdinInput(
   const { fmt } = ctx.channel;
   if (!text) return;
 
+  // 0. Kill switch: /q or "stop" (case-insensitive)
+  const lowerText = text.toLowerCase();
+  if (lowerText === "/q" || lowerText === "stop") {
+    const remote = ctx.sessionManager.getAttachedRemote(chatId) 
+      || (ctx.sessionManager.listRemotesForUser(userId).length === 1 && !msg.isGroup ? ctx.sessionManager.listRemotesForUser(userId)[0] : null);
+    
+    if (remote && remote.ownerUserId === userId) {
+      ctx.sessionManager.requestRemoteStop(remote.id);
+      await ctx.channel.send(chatId, `${fmt.escape("⛳️ Interruption sent to session")} ${fmt.code(remote.id)}`);
+      return;
+    }
+  }
+
   // Helper: when routing input from a group, subscribe the group to session output
   const maybeSubscribeGroup = (sessionId: string) => {
     if (msg.isGroup) {

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -51,6 +51,11 @@ export const __cliRunTestUtils = {
   parseJsonlMessage,
   isVersionBelow,
   extractApprovalPrompt,
+  shouldInjectBridgePrompt: (cmdName: string, cleanText: string, ptyBuffer: string): boolean => {
+    const patterns = INITIAL_PROMPT_PATTERNS[cmdName] || ["> ", "? "];
+    return patterns.some(p => cleanText.includes(p) || ptyBuffer.endsWith(p));
+  },
+  getBridgePromptText: () => BRIDGE_PROMPT_TEXT,
   resetParserState: () => {
     toolUseIdToName.clear();
     toolUseIdToInput.clear();

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -9,7 +9,7 @@ import { stripAnsiReadable } from "../utils/ansi";
 import { paths, ensureDirs } from "../config/paths";
 import { getChannelName, getChannelType } from "../channel/id";
 import { watch, readdirSync, statSync, readFileSync, type FSWatcher } from "fs";
-import { open } from "fs/promises";
+import { open, writeFile, rm } from "fs/promises";
 import { homedir, platform } from "os";
 import { join, basename } from "path";
 import { createHash } from "crypto";
@@ -32,6 +32,14 @@ const APPROVAL_PATTERNS: Record<string, { promptText: string; optionText: string
   // pi: { promptText: "...", optionText: "..." },
   // kimi: { promptText: "...", optionText: "..." },
 };
+
+const INITIAL_PROMPT_PATTERNS: Record<string, string[]> = {
+  gemini: ["> "],
+  pi: ["? "],
+  kimi: ["? "],
+};
+
+const BRIDGE_PROMPT_TEXT = "[touchgrass] This is a terminal bridge. All subsequent messages are proxied from a chat interface. You are interacting with the user through touchgrass.";
 
 // Test-only accessors for CLI arg parsing behavior.
 export const __cliRunTestUtils = {
@@ -2158,6 +2166,26 @@ export async function runRun(): Promise<void> {
     let requestedResumeSessionRef: string | null = null;
     let stayAliveAfterKill = false;
     let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+
+    let bridgePromptFile: string | null = null;
+    let bridgePromptWritten = false;
+    let shouldInjectBridgePrompt = false;
+
+    // Use --append-system-prompt for tools that support it (Claude, Codex)
+    if (!resumeId && !codexResumeLast && !kimiResumeContinue && !requestedResumeSessionRef) {
+      if (cmdName === "claude" || cmdName === "codex") {
+        try {
+          bridgePromptFile = join(paths.dir, `bridge-prompt-${remoteId || Math.random().toString(36).slice(2)}.md`);
+          await writeFile(bridgePromptFile, BRIDGE_PROMPT_TEXT);
+          cmdArgs.push("--append-system-prompt", bridgePromptFile);
+          bridgePromptWritten = true;
+        } catch {}
+      } else {
+        // Mark for terminal.write fallback based on pattern detection
+        shouldInjectBridgePrompt = true;
+      }
+    }
+
     const proc = Bun.spawn([executable, ...cmdArgs], {
       terminal: {
         cols: process.stdout.columns || 80,
@@ -2167,8 +2195,22 @@ export async function runRun(): Promise<void> {
           // Buffer last ~1000 chars of PTY output for prompt detection
           // Uses stripAnsiReadable to replace ANSI codes with spaces (preserves word boundaries)
           const text = Buffer.from(data).toString("utf-8");
-          ptyBuffer += stripAnsiReadable(text);
+          const cleanText = stripAnsiReadable(text);
+          ptyBuffer += cleanText;
           if (ptyBuffer.length > 2000) ptyBuffer = ptyBuffer.slice(-1000);
+
+          // terminal.write fallback injection after detecting initial prompt
+          if (shouldInjectBridgePrompt && !bridgePromptWritten) {
+            const patterns = INITIAL_PROMPT_PATTERNS[cmdName] || ["> ", "? "];
+            if (patterns.some(p => cleanText.includes(p) || ptyBuffer.endsWith(p))) {
+              bridgePromptWritten = true;
+              setTimeout(() => {
+                try {
+                  _terminal.write(Buffer.from(`\r\n${BRIDGE_PROMPT_TEXT}\r\n`));
+                } catch {}
+              }, 500);
+            }
+          }
 
           const result = extractApprovalPrompt(cmdName, ptyBuffer);
           if (result && result.promptText !== lastNotifiedPrompt) {
@@ -2188,16 +2230,6 @@ export async function runRun(): Promise<void> {
     });
 
     const terminal = proc.terminal!;
-
-    // Inject Touchgrass bridge context for new sessions so the agent tool
-    // knows it's being proxied through a terminal bridge.
-    if (!resumeId && !codexResumeLast && !kimiResumeContinue && !requestedResumeSessionRef) {
-      setTimeout(() => {
-        try {
-          terminal.write(Buffer.from("\r\n[touchgrass] This is a terminal bridge. All subsequent messages are proxied from a chat interface. You are interacting with the user through touchgrass.\r\n"));
-        } catch {}
-      }, 1000);
-    }
 
     // Prevent idle sleep on macOS while the tool is running
     let caffeinateProc: { kill(): void } | null = null;
@@ -2655,6 +2687,11 @@ export async function runRun(): Promise<void> {
     if (forceKillTimer) clearTimeout(forceKillTimer);
     if (watcherRef.current) watcherRef.current.close();
     if (watcherRef.dir) watcherRef.dir.close();
+    if (bridgePromptFile) {
+      try {
+        await rm(bridgePromptFile).catch(() => {});
+      } catch {}
+    }
 
     if (requestedResumeSessionRef) {
       cmdArgs = buildResumeCommandArgs(cmdName as "claude" | "codex" | "pi" | "kimi" | "gemini", cmdArgs, requestedResumeSessionRef);

--- a/packages/cli/src/cli/run.ts
+++ b/packages/cli/src/cli/run.ts
@@ -343,6 +343,8 @@ const SUPPORTED_COMMANDS: Record<string, string[]> = {
   gemini: ["gemini"],
 };
 
+type SupportedCommand = keyof typeof SUPPORTED_COMMANDS;
+
 // Minimum supported tool versions. Below these, touchgrass may not work correctly.
 const MIN_TOOL_VERSIONS: Record<string, string> = {
   claude: "2.1.0",
@@ -2004,6 +2006,9 @@ export async function runRun(): Promise<void> {
     // - PI: --continue/-c (latest session), --session <path>
     // - Kimi: --session <session-id>, --continue/-C (latest session)
     let resumeSessionFile: string | null = null;
+    let resumeId: string | null = null;
+    let codexResumeLast = false;
+    let kimiResumeContinue = false;
 
     // Snapshot existing JSONL files BEFORE spawning so the tool's new file is detected
     const projectDir = channel && chatId ? getSessionDir(cmdName) : "";
@@ -2026,9 +2031,6 @@ export async function runRun(): Promise<void> {
       }
 
       // Check for resume session ID in args
-      let resumeId: string | null = null;
-      let codexResumeLast = false;
-      let kimiResumeContinue = false;
       if (cmdName === "codex") {
         const parsed = parseCodexResumeArgs(cmdArgs);
         resumeId = parsed.resumeId;
@@ -2186,6 +2188,16 @@ export async function runRun(): Promise<void> {
     });
 
     const terminal = proc.terminal!;
+
+    // Inject Touchgrass bridge context for new sessions so the agent tool
+    // knows it's being proxied through a terminal bridge.
+    if (!resumeId && !codexResumeLast && !kimiResumeContinue && !requestedResumeSessionRef) {
+      setTimeout(() => {
+        try {
+          terminal.write(Buffer.from("\r\n[touchgrass] This is a terminal bridge. All subsequent messages are proxied from a chat interface. You are interacting with the user through touchgrass.\r\n"));
+        } catch {}
+      }, 1000);
+    }
 
     // Prevent idle sleep on macOS while the tool is running
     let caffeinateProc: { kill(): void } | null = null;
@@ -2486,11 +2498,11 @@ export async function runRun(): Promise<void> {
           logErr: () => {},
         })
       : null;
-    if (remoteId && chatId && ownerUserId && recovery) {
-      const getRecoveryName = (): string | undefined => {
-        return readSessionManifestSync(remoteId)?.name ?? manifest?.name;
-      };
+    const getRecoveryName = (): string | undefined => {
+      return remoteId ? readSessionManifestSync(remoteId)?.name ?? manifest?.name : manifest?.name;
+    };
 
+    if (remoteId && chatId && ownerUserId && recovery) {
       pollTimer = setInterval(async () => {
         if (processingInput || recovery.isRecovering()) return;
         try {


### PR DESCRIPTION
This PR enhances the terminal bridge and session management to improve the interaction between chat interfaces and underlying AI tools (Claude, Codex, Gemini, Pi, Kimi). It introduces a system prompt injection mechanism, adds a convenient session kill switch, and provides comprehensive test coverage for these new features.

  Key Changes:

   * Terminal Bridge Prompt Injection:
       * Added a system prompt injection mechanism ([touchgrass] This is a terminal bridge...) to inform AI tools they are being proxied.
       * For Claude and Codex, the prompt is injected via the --append-system-prompt flag using a temporary file.
       * For Gemini, Pi, and Kimi, a fallback mechanism writes the prompt directly to the terminal PTY upon detecting the initial tool prompt (e.g., >  or ? ).
       * Refactored prompt detection into testable helpers in run.ts.
   * Session Kill Switch:
       * Implemented a "kill switch" in the chat interface: sending /q or stop (case-insensitive) now triggers an immediate interruption and stops the active session.
   * Improved Session Resilience:
       * Refactored getRecoveryName to safely handle undefined remoteId during session recovery.
       * Ensured cleanup of temporary bridge prompt files after session termination.
       * Fixed scope issues for session resume variables in the main run loop.
   * Testing:
       * New packages/cli/src/__tests__/bridge-prompt.test.ts: Verifies the logic for terminal bridge prompt detection across different tools.
       * New packages/cli/src/__tests__/stdin-input.test.ts: Validates the /q kill switch and file mention prepending.
       * Updated packages/cli/src/__tests__/codex-args.test.ts: Ensures correct argument parsing for resume and restart scenarios.